### PR TITLE
Fix building with kernel 5.10

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -1,7 +1,7 @@
 config RTL8733BU
 	depends on MMC
 	tristate "Realtek 8733B USB WiFi"
-	---help---
+	help
 	  Realtek RTL8733BU chipset driver
 	  802.11ac USB wireless network adapter
 


### PR DESCRIPTION
Ругалось так
```
drivers/net/wireless/realtek/rtl8733bu/Kconfig:5: syntax error
drivers/net/wireless/realtek/rtl8733bu/Kconfig:4: unknown statement "---help---"
```