### PR TITLE
rtl8733bu: move some log messages to info debug level

### DIFF
--- a/core/rtw_mlme.c
+++ b/core/rtw_mlme.c
@@ -2525,7 +2525,7 @@ void rtw_free_assoc_resources(_adapter *adapter, u8 lock_scanned_queue)
 			}
 #endif /* CONFIG_P2P */
 		} else
-			RTW_ERR("Free disconnecting network of scanned_queue failed due to pwlan == NULL\n\n");
+			RTW_INFO("Free disconnecting network of scanned_queue failed due to pwlan == NULL\n\n");
 	}
 
 	if ((check_fwstate(pmlmepriv, WIFI_ADHOC_MASTER_STATE) && (adapter->stapriv.asoc_sta_count == 1))

--- a/hal/rtl8733b/rtl8733b_cmd.c
+++ b/hal/rtl8733b/rtl8733b_cmd.c
@@ -638,8 +638,13 @@ void rtl8733b_c2h_handler_no_io(PADAPTER adapter, u8 *pbuf, u16 length)
 	default:
 		/* Others may need I/O, run in command thread */
 		res = rtw_c2h_packet_wk_cmd(adapter, pbuf, length);
-		if (res == _FAIL)
-			RTW_ERR("%s: C2H(%d) enqueue FAIL!\n", __FUNCTION__, id);
+		if (res == _FAIL) {
+			if (id == C2H_BT_INFO || id == C2H_MAILBOX_STATUS) {
+				RTW_INFO("%s: C2H(%d) enqueue FAIL!\n", __FUNCTION__, id);
+			} else 
+				RTW_ERR("%s: C2H(%d) enqueue FAIL!\n", __FUNCTION__, id);
+			}
+		}
 		break;
 	}
 }

--- a/hal/rtl8733b/rtl8733b_cmd.c
+++ b/hal/rtl8733b/rtl8733b_cmd.c
@@ -641,7 +641,7 @@ void rtl8733b_c2h_handler_no_io(PADAPTER adapter, u8 *pbuf, u16 length)
 		if (res == _FAIL) {
 			if (id == C2H_BT_INFO || id == C2H_MAILBOX_STATUS) {
 				RTW_INFO("%s: C2H(%d) enqueue FAIL!\n", __FUNCTION__, id);
-			} else 
+			} else {
 				RTW_ERR("%s: C2H(%d) enqueue FAIL!\n", __FUNCTION__, id);
 			}
 		}


### PR DESCRIPTION
* the driver receives C2H_MAILBOX_STATUS and C2H_BT_INFO too early before full initialization. It leads to wrong error messages in dmesg. C2H_MAILBOX_STATUS only prints debug message so it is not a problem if it is not handled. C2H_BT_INFO repeats often and is successfully handled after full initialization
* Free assoc resources error message is moved to info