### PR TITLE
rtl8733bu: use __dev_addr_set()

### DIFF
--- a/os_dep/linux/mlme_linux.c
+++ b/os_dep/linux/mlme_linux.c
@@ -412,8 +412,7 @@ int hostapd_mode_init(_adapter *padapter)
 	mac[4] = 0x11;
 	mac[5] = 0x12;
 
-	_rtw_memcpy(pnetdev->dev_addr, mac, ETH_ALEN);
-
+	__dev_addr_set(pnetdev, mac, ETH_ALEN);
 
 	rtw_netif_carrier_off(pnetdev);
 

--- a/os_dep/linux/os_intfs.c
+++ b/os_dep/linux/os_intfs.c
@@ -1630,7 +1630,7 @@ static int rtw_net_set_mac_address(struct net_device *pnetdev, void *addr)
 	}
 
 	_rtw_memcpy(adapter_mac_addr(padapter), sa->sa_data, ETH_ALEN); /* set mac addr to adapter */
-	_rtw_memcpy(pnetdev->dev_addr, sa->sa_data, ETH_ALEN); /* set mac addr to net_device */
+	__dev_addr_set(pnetdev, sa->sa_data, ETH_ALEN); /* set mac addr to net_device */
 
 #if 0
 	if (rtw_is_hw_init_completed(padapter)) {
@@ -2183,7 +2183,7 @@ int rtw_os_ndev_register(_adapter *adapter, const char *name)
 	/* alloc netdev name */
 	rtw_init_netdev_name(ndev, name);
 
-	_rtw_memcpy(ndev->dev_addr, adapter_mac_addr(adapter), ETH_ALEN);
+	__dev_addr_set(ndev, adapter_mac_addr(adapter), ETH_ALEN);
 
 	/* Tell the network stack we exist */
 
@@ -3255,7 +3255,7 @@ int _netdev_vir_if_open(struct net_device *pnetdev)
 		rtw_mbid_camid_alloc(padapter, adapter_mac_addr(padapter));
 #endif
 		rtw_init_wifidirect_addrs(padapter, adapter_mac_addr(padapter), adapter_mac_addr(padapter));
-		_rtw_memcpy(pnetdev->dev_addr, adapter_mac_addr(padapter), ETH_ALEN);
+		__dev_addr_set(pnetdev, adapter_mac_addr(padapter), ETH_ALEN);
 	}
 #endif /*CONFIG_PLATFORM_INTEL_BYT*/
 
@@ -4011,7 +4011,7 @@ int _netdev_open(struct net_device *pnetdev)
 		rtw_mbid_camid_alloc(padapter, adapter_mac_addr(padapter));
 #endif
 		rtw_init_wifidirect_addrs(padapter, adapter_mac_addr(padapter), adapter_mac_addr(padapter));
-		_rtw_memcpy(pnetdev->dev_addr, adapter_mac_addr(padapter), ETH_ALEN);
+		__dev_addr_set(pnetdev, adapter_mac_addr(padapter), ETH_ALEN);
 #endif /* CONFIG_PLATFORM_INTEL_BYT */
 
 		rtw_clr_surprise_removed(padapter);


### PR DESCRIPTION
> netdev->dev_addr should only be modified via helpers

For more details see https://github.com/wirenboard/linux/commit/d07b26f5bbea9ade34dfd6abea7b3ca056c03cd1

```sh
[   30.288988] rtl8733bu 7-1:1.2 wlan0: Current addr:  98 03 cf b1 db a4 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
[   30.302257] rtl8733bu 7-1:1.2 wlan0: Expected addr: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
[   30.315557] ------------[ cut here ]------------
[   30.320251] netdevice: wlan0: Incorrect netdev->dev_addr
[   30.325656] WARNING: CPU: 1 PID: 875 at net/core/dev_addr_lists.c:519 dev_addr_check+0xb4/0x144
[   30.334368] Modules linked in: qrtr af_alg btusb btrtl btintel btmtk 8733bu btbcm bluetooth ecdh_generic cfg80211 ecc rfkill crct10dif_ce sun6i_dma sunxi_wdt drm fuse backlight ip_tables x_tables ipv6
[   30.352261] CPU: 1 PID: 875 Comm: NetworkManager Not tainted 6.8.0-wb1 #10
[   30.359162] Hardware name: Wiren Board 8.x (DT)
[   30.363709] pstate: 60000005 (nZCv daif -PAN -UAO -TCO -DIT -SSBS BTYPE=--)
[   30.370667] pc : dev_addr_check+0xb4/0x144
[   30.374771] lr : dev_addr_check+0xb4/0x144
[   30.378868] sp : ffff800081d4b530
[   30.382181] x29: ffff800081d4b530 x28: ffff800080db11c0 x27: 0000000000000000
[   30.389323] x26: ffff80007991f3c0 x25: 0000000000000001 x24: 0000000000000000
[   30.396474] x23: ffff0000c032e330 x22: 0000000000001002 x21: ffff800080ef7cc0
[   30.403639] x20: ffff0000c032e120 x19: ffff0000c032e000 x18: 0000000000000000
[   30.410778] x17: 0000000000000000 x16: 0000000000000000 x15: 0000000000000030
[   30.417914] x14: ffff800081330450 x13: 00000000000004dd x12: 000000000000019f
[   30.425052] x11: 2074636572726f63 x10: ffff800081388450 x9 : 00000000fffff000
[   30.432191] x8 : ffff800081330450 x7 : ffff800081388450 x6 : 0000000000000000
[   30.439328] x5 : 0000000000000000 x4 : 0000000000000000 x3 : 0000000000000000
[   30.446465] x2 : 0000000000000000 x1 : 0000000000000000 x0 : ffff0000c98f9100
[   30.453604] Call trace:
[   30.456051]  dev_addr_check+0xb4/0x144
[   30.459808]  __dev_open+0x40/0x1d8
[   30.463218]  __dev_change_flags+0x190/0x208
[   30.467407]  dev_change_flags+0x24/0x6c
[   30.471250]  do_setlink+0x21c/0xdec
[   30.474745]  __rtnl_newlink+0x494/0x8c4
[   30.478585]  rtnl_newlink+0x50/0x7c
[   30.482077]  rtnetlink_rcv_msg+0x124/0x390
[   30.486175]  netlink_rcv_skb+0x5c/0x140
[   30.490017]  rtnetlink_rcv+0x18/0x24
[   30.493596]  netlink_unicast+0x274/0x340
[   30.497521]  netlink_sendmsg+0x180/0x3c4
[   30.501446]  ____sys_sendmsg+0x220/0x284
[   30.505374]  ___sys_sendmsg+0x80/0xdc
[   30.509037]  __sys_sendmsg+0x68/0xc4
[   30.512615]  __arm64_sys_sendmsg+0x24/0x30
[   30.516711]  invoke_syscall+0x48/0x114
[   30.520468]  el0_svc_common.constprop.0+0x40/0xe0
[   30.525174]  do_el0_svc+0x1c/0x28
[   30.528495]  el0_svc+0x34/0xb8
[   30.531553]  el0t_64_sync_handler+0xc0/0xc4
[   30.535737]  el0t_64_sync+0x190/0x194
[   30.539403] ---[ end trace 0000000000000000 ]---
```