### PR TITLE
Disallow scan on buddy interface if configured as client

### DIFF
--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -3212,7 +3212,8 @@ static int cfg80211_rtw_scan(struct wiphy *wiphy
 	_adapter *padapter;
 	struct wireless_dev *wdev;
 	struct rtw_wdev_priv *pwdev_priv;
-	struct mlme_priv *pmlmepriv = NULL, *buddy_mlmepriv;
+	struct mlme_priv *pmlmepriv = NULL;
+	struct mlme_priv *buddy_mlmepriv;
 	struct dvobj_priv *dvobj;
 #ifdef CONFIG_P2P
 	struct wifidirect_info *pwdinfo;

--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -3241,6 +3241,19 @@ static int cfg80211_rtw_scan(struct wiphy *wiphy
 
 	pwdev_priv = adapter_wdev_data(padapter);
 	pmlmepriv = &padapter->mlmepriv;
+	
+	// check if buddy adapter is configured as client, if so, deny scan immediately	
+	RTW_DBG("scan request for %s\n", padapter->pnetdev->name);
+	RTW_DBG("this wlan state %08x\n", pmlmepriv->fw_state);
+	if (pmlmepriv) {
+		RTW_DBG("buddy wlan state %08x\n", pmlmepriv->fw_state);
+		if (check_fwstate(pmlmepriv, WIFI_ASOC_STATE) == _TRUE) {
+			RTW_DBG("scan on %s is cancelled, another interface is the client here\n", padapter->pnetdev->name);
+			ret = -EBUSY;
+			goto exit;
+		}
+	}
+		
 #ifdef CONFIG_P2P
 	pwdinfo = &(padapter->wdinfo);
 #endif /* CONFIG_P2P */

--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -3212,7 +3212,8 @@ static int cfg80211_rtw_scan(struct wiphy *wiphy
 	_adapter *padapter;
 	struct wireless_dev *wdev;
 	struct rtw_wdev_priv *pwdev_priv;
-	struct mlme_priv *pmlmepriv = NULL;
+	struct mlme_priv *pmlmepriv = NULL;	
+	struct dvobj_priv *dvobj;
 #ifdef CONFIG_P2P
 	struct wifidirect_info *pwdinfo;
 #endif /* CONFIG_P2P */
@@ -3244,16 +3245,27 @@ static int cfg80211_rtw_scan(struct wiphy *wiphy
 	
 	// check if buddy adapter is configured as client, if so, deny scan immediately	
 	RTW_DBG("scan request for %s\n", padapter->pnetdev->name);
-	RTW_DBG("this wlan state %08x\n", pmlmepriv->fw_state);
-	if (pmlmepriv) {
-		RTW_DBG("buddy wlan state %08x\n", pmlmepriv->fw_state);
-		if (check_fwstate(pmlmepriv, WIFI_ASOC_STATE) == _TRUE) {
-			RTW_DBG("scan on %s is cancelled, another interface is the client here\n", padapter->pnetdev->name);
+	RTW_DBG("this wlan state: %08x\n", pmlmepriv->fw_state);
+	dvobj = adapter_to_dvobj(padapter);
+	for (i = 0; i < dvobj->iface_nums; i++) {
+		_adapter *iface = dvobj->padapters[i];
+		struct mlme_priv *buddy_mlmepriv;
+
+		if (iface == NULL || iface == padapter || rtw_is_adapter_up(iface) == _FALSE)
+			continue;
+
+		buddy_mlmepriv = &iface->mlmepriv;
+		if (buddy_mlmepriv == NULL)
+			continue;
+		
+		RTW_DBG("buddy wlan state: %08x\n", buddy_mlmepriv->fw_state);
+		if (check_fwstate(buddy_mlmepriv, WIFI_STATION_STATE) == _TRUE) {
+			RTW_DBG("scan on %s is cancelled, interface %s is the client here\n", padapter->pnetdev->name, iface->pnetdev->name);
 			ret = -EBUSY;
 			goto exit;
 		}
 	}
-		
+
 #ifdef CONFIG_P2P
 	pwdinfo = &(padapter->wdinfo);
 #endif /* CONFIG_P2P */

--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -3212,7 +3212,7 @@ static int cfg80211_rtw_scan(struct wiphy *wiphy
 	_adapter *padapter;
 	struct wireless_dev *wdev;
 	struct rtw_wdev_priv *pwdev_priv;
-	struct mlme_priv *pmlmepriv = NULL;
+	struct mlme_priv *pmlmepriv = NULL, *buddy_mlmepriv;
 	struct dvobj_priv *dvobj;
 #ifdef CONFIG_P2P
 	struct wifidirect_info *pwdinfo;
@@ -3249,15 +3249,11 @@ static int cfg80211_rtw_scan(struct wiphy *wiphy
 	dvobj = adapter_to_dvobj(padapter);
 	for (i = 0; i < dvobj->iface_nums; i++) {
 		_adapter *iface = dvobj->padapters[i];
-		struct mlme_priv *buddy_mlmepriv;
 
 		if (iface == NULL || iface == padapter || rtw_is_adapter_up(iface) == _FALSE)
 			continue;
 
 		buddy_mlmepriv = &iface->mlmepriv;
-		if (buddy_mlmepriv == NULL)
-			continue;
-		
 		RTW_DBG("buddy wlan state: %08x\n", buddy_mlmepriv->fw_state);
 		if (check_fwstate(buddy_mlmepriv, WIFI_STATION_STATE) == _TRUE) {
 			RTW_DBG("scan on %s is cancelled, interface %s is the client here\n", padapter->pnetdev->name, iface->pnetdev->name);

--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -3212,7 +3212,7 @@ static int cfg80211_rtw_scan(struct wiphy *wiphy
 	_adapter *padapter;
 	struct wireless_dev *wdev;
 	struct rtw_wdev_priv *pwdev_priv;
-	struct mlme_priv *pmlmepriv = NULL;	
+	struct mlme_priv *pmlmepriv = NULL;
 	struct dvobj_priv *dvobj;
 #ifdef CONFIG_P2P
 	struct wifidirect_info *pwdinfo;


### PR DESCRIPTION
NetworkManager запускает сканирование доступных сетей с интервалом около 30 секунд. В случае, когда один из интерфейсов работает как клиент, это приводит к тому, что соединение прерывается на несколько секунд.
 
Добавил запрет сканирования сетей, если один из интерфейсов настроен как клиент, по аналогии с фиксом этой же проблемы в драйвере `rtl8723bu`: https://github.com/wirenboard/rtl8723bu/commit/90635219abbf9de0cc3d660038200e4ef9cb2df4