### PR TITLE
rtl8733bu: move BusyTraffic log messages to debug level

### DIFF
--- a/core/rtw_mlme.c
+++ b/core/rtw_mlme.c
@@ -2330,7 +2330,7 @@ u8 _rtw_sitesurvey_condition_check(const char *caller, _adapter *adapter, bool c
 	    && (rtw_get_passing_time_ms(pmlmepriv->lastscantime) >
 		registry_par->scan_interval_thr)
 	    && rtw_mi_busy_traffic_check(adapter)) {
-		RTW_WARN("%s ("ADPT_FMT") : scan abort!! BusyTraffic\n",
+		RTW_DBG("%s ("ADPT_FMT") : scan abort!! BusyTraffic\n",
 			 caller, ADPT_ARG(adapter));
 		ss_condition = SS_DENY_BUSY_TRAFFIC;
 		goto _exit;


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
ребейз https://github.com/wirenboard/rtl8733bu/pull/8
![Screen Shot 2025-07-09 at 01 47 07](https://github.com/user-attachments/assets/ec92000f-23e3-4923-ad13-393d301633a4)


___________________________________
**Что поменялось для пользователей:**
убирает BusyTraffic спам в dmesg.

___________________________________
**Как проверял/а:**
никак